### PR TITLE
build: use secure npm package manager config

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,11 @@
+# npm security best practices
+# Source: https://github.com/lirantal/npm-security-best-practices
+
+# Do not run any lifecycle hook scripts such as postinstall for packages
+ignore-scripts=true
+
+# Do not allow Git / GitHub related sources for packages
+allow-git=none
+
+# Require at least 30 days since package release
+min-release-age=30


### PR DESCRIPTION
Scaffolds a secure package manager config file for this repo, following the recommendations in https://github.com/lirantal/npm-security-best-practices.

- For npm repos: adds `.npmrc` (disables lifecycle scripts, blocks git sources, enforces a 30-day minimum release age).
- For pnpm repos: adds `pnpm-workspace.yaml` with `minimumReleaseAge`, `trustPolicy`, `strictDepBuilds`, and `blockExoticSubdeps`.

This PR was opened as part of a bulk security-hardening pass across my repos. If this overwrites a custom config that was intentional, please close and revisit manually.